### PR TITLE
[codex] Move CMR AI paper to other publications

### DIFF
--- a/research.html
+++ b/research.html
@@ -170,13 +170,20 @@ Data fusion, limited data, deep learning, causal inference
 <h3>Other Publications</h3>
 
 <ol start="12">
-<li><p>Damodaran, A.; <b>McCarthy, Daniel</b>; Cohen, M. (2022), "IPO Disclosures Are Ripe for Reform," <i>MIT Sloan Management Review</i>, <a href="https://sloanreview.mit.edu/article/ipo-disclosures-are-ripe-for-reform/">Link</a><br />
+<li><p>Cohen, Maxime C.; Hage-Youssef, E.; <b>McCarthy, Daniel</b>; Sokol, D. Daniel, "Choosing Your Strategy Under Disruption: Three Bets on AI's Future," <i>Forthcoming at California Management Review</i>, <a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6331258">Link</a><br />
 </div>
 </p>
 </li>
 </ol>
 
 <ol start="13">
+<li><p>Damodaran, A.; <b>McCarthy, Daniel</b>; Cohen, M. (2022), "IPO Disclosures Are Ripe for Reform," <i>MIT Sloan Management Review</i>, <a href="https://sloanreview.mit.edu/article/ipo-disclosures-are-ripe-for-reform/">Link</a><br />
+</div>
+</p>
+</li>
+</ol>
+
+<ol start="14">
 <li><p><b>McCarthy, Daniel</b>; Fader, Peter (2020), "How to Value a Company by Analyzing Its Customers," <i>Harvard Business Review</i>, 98 (1), 51-55, <a href="https://hbr.org/2020/01/are-you-undervaluing-your-customers#how-to-value-a-company-by-analyzing-its-customers">Link</a> <br />
 </div>
 </p>
@@ -186,11 +193,6 @@ Data fusion, limited data, deep learning, causal inference
 <h3>Working Papers</h3>
 
 <ol start="1">
-<li>Cohen, Maxime C.; Hage-Youssef, E.; <b>McCarthy, Daniel</b>; Sokol, D. Daniel, "Three Strategic Bets on AI's Future," <i>Preparing for submission</i>, <a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6331258">Link</a>
-</li>
-</ol>
-
-<ol start="2">
 <li><b>McCarthy, Daniel</b>; Oblander, E. Shin; Park, Young-Hoon; Yoon, Yeohong, "Expanding Markets or Capturing Share: Effects of Subscription on Spending and Share-of-Wallet in Restaurant Delivery," <i>Revising for third round review at Journal of Marketing Research (major revision)</i>, <a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4913436">Link</a>
   <ul>
     <li>MSI Working Paper Series (<a href="https://www.msi.org/working-paper/expanding-markets-or-capturing-share-the-effects-of-subscription-on-spending-and-share-of-wallet-in-restaurant-delivery/">Link</a>, <a href="https://www.msi.org/research-recap/food-service-subscription-plans-deliver-for-both-customers-and-companies/">Research Recap</a>)</li>
@@ -199,12 +201,12 @@ Data fusion, limited data, deep learning, causal inference
 </li>
 </ol>
 
-<ol start="3">
+<ol start="2">
 <li>Ye, Taotao; Shankar, Venkatesh; <b>McCarthy, Daniel</b>, "Omnichannel Shopping and Mobile App Usage After Mobile App Payment Method Introduction," <i>Revising for second round review at Journal of Marketing Research (major revision)</i>, <a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5713643">Link</a>
 </li>
 </ol>
 
-<ol start="4">
+<ol start="3">
 <li><p>Kim, Kyeongbin; <b>McCarthy, Daniel</b>; Lee, Dokyun, "Generative Multi-Task Learning for Customer-Base Analysis: Evidence from 1,001 Companies," <i>Under review</i></p>
   <ul>
   <li>2024 MSI Alden G. Clayton Doctoral Dissertation Proposal Competition (Honorable Mention)</li>
@@ -214,7 +216,7 @@ Data fusion, limited data, deep learning, causal inference
 </li>
 </ol>
 
-<ol start="5">
+<ol start="4">
   <li>Taylor, Wayne; <b>McCarthy, Daniel</b>; Wilbur, Kenneth, "The Effects of Sports Betting Legalization on Irresponsible Gambling," <i>Under review</i>, <a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4856684">Link</a>
     <ul>
     <li>Media Coverage: Bloomberg (<a href="https://archive.ph/0dlD8">9/27/24</a>), PA Independent Fiscal Office (<a href="http://www.ifo.state.pa.us/releases/793/Who-Pays-Pennsylvania-Gaming-Taxes/">9/25/24</a>), Washington Monthly (<a href="https://washingtonmonthly.com/2024/10/29/the-app-always-wins/">10/29/24</a>), USA Today, ReadWrite (<a href="https://readwrite.com/new-study-measures-sports-betting-boom-finds-rise-in-irresponsible-gambling/">7/18/25</a>), MarketWatch, Seeking Alpha (<a href="https://seekingalpha.com/pr/20170139-sports-betting-boom-new-study-measures-spending-surge-new-tax-revenue-and-rising-public">7/17/25</a>), Cox Today (<a href="https://coxtoday.smu.edu/2024/09/17/to-legalize-online-gambling-or-not-its-complicated/">9/17/24</a>), Axios (<a href="https://www.axios.com/2025/12/14/sports-betting-gambling-young-men-crisis">12/14/25</a>)</li>
@@ -222,12 +224,12 @@ Data fusion, limited data, deep learning, causal inference
   </li>
 </ol>
 
-<ol start="6">
+<ol start="5">
 <li>Gurlek, Ragip; <b>McCarthy, Daniel</b>; Samaha, Stephen; Du, Rex; Lee, Donald, "Modeling the Evolution of Customer Balances," <i>In preparation</i>
 </li>
 </ol>
 
-<ol start="7">
+<ol start="6">
   <li><b>McCarthy, Daniel</b>; Libai, Barak; Schoenmueller, Verena, "The Churn Dynamics of Young Brands," <i>In preparation</i>, <a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4722115">Link</a>
     <ul>
     <li>Media Coverage: Magis (<a href="https://magis.substack.com/p/churn-paradox">2/20/24</a>), Modern Retail (<a href="https://www.modernretail.co/marketing/dtc-briefing-why-churn-rate-isnt-always-a-good-indicator-of-retention/">2/27/24</a>), Let's Talk Loyalty (<a href="https://letstalkloyalty.com/what-we-thought-we-knew-about-retention-and-customer-lifetime-value/">6/26/24</a>)</li>


### PR DESCRIPTION
## Summary

Moves the AI strategy paper from Working Papers to Other Publications based on the July 1, 2026 California Management Review acceptance email.

## Changes

- Adds the paper as Other Publications item 12 with status Forthcoming at California Management Review.
- Uses the accepted CMR title: Choosing Your Strategy Under Disruption: Three Bets on AI's Future.
- Shifts MIT Sloan Management Review and Harvard Business Review to items 13 and 14.
- Removes the old Working Papers entry and renumbers the remaining working papers.

## Validation

- Checked the Gmail thread for the CMR acceptance status.
- Ran git diff --check; only the existing Windows line-ending warning appeared.