### PR TITLE
Add 2026 Dawson's Lawn Supply case

### DIFF
--- a/teaching.html
+++ b/teaching.html
@@ -97,6 +97,12 @@
 </li>
 </ul>
 
+<ul>
+<li><p><b><a href="https://hbsp.harvard.edu/product/8984-HTM-ENG">Dawson's Lawn Supply: Digging Into CLV</a></b>, Cook, J.; McCarthy, D.; Fader, P. (2026), <i>Harvard Business Impact Quick Case 8984</i><br />
+</p>
+</li>
+</ul>
+
 
 
 


### PR DESCRIPTION
## What changed

- Added *Dawson's Lawn Supply: Digging Into CLV* to the Case Materials section in `teaching.html`.
- Linked the title to the canonical Harvard Business Impact product page.
- Matched the existing title-link, author, year, and italic publication-label structure used for Blue Apron and Eplay.

## Why

The 2026 Quick Case should appear alongside the other published teaching cases and mirror the updated Word CV.

## Validation

- Confirmed `git diff --check` passes.
- Rendered the edited page locally in Chrome and verified the complete three-case section is readable with no clipping or spacing regression.
- Confirmed the entry uses the official author order, 2026 date, Quick Case type, and item 8984.
